### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/101/910/981/101910981.geojson
+++ b/data/101/910/981/101910981.geojson
@@ -368,6 +368,9 @@
         "wk:page":"Tekirda\u011f"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"72ae783e135571f315d0fc0dfd7a4c6d",
     "wof:hierarchy":[
         {
@@ -379,7 +382,7 @@
         }
     ],
     "wof:id":101910981,
-    "wof:lastmodified":1566588223,
+    "wof:lastmodified":1582343862,
     "wof:name":"Tekirda\u011f",
     "wof:parent_id":890461857,
     "wof:placetype":"locality",

--- a/data/101/911/157/101911157.geojson
+++ b/data/101/911/157/101911157.geojson
@@ -90,6 +90,9 @@
         "wk:page":"K\u0131y\u0131k\u00f6y"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ae5b46137d3d1edb4b6ca2bad865b3cf",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":101911157,
-    "wof:lastmodified":1566588222,
+    "wof:lastmodified":1582343862,
     "wof:name":"K\u0131y\u0131k\u00f6y",
     "wof:parent_id":890460583,
     "wof:placetype":"locality",

--- a/data/101/912/633/101912633.geojson
+++ b/data/101/912/633/101912633.geojson
@@ -47,6 +47,9 @@
         "qs_pg:id":1337741
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c946709bf83e84d2422e60ea925a869b",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":101912633,
-    "wof:lastmodified":1566588222,
+    "wof:lastmodified":1582343862,
     "wof:name":"Yenimahalle",
     "wof:parent_id":890462765,
     "wof:placetype":"locality",

--- a/data/101/912/681/101912681.geojson
+++ b/data/101/912/681/101912681.geojson
@@ -130,6 +130,9 @@
         "wd:id":"Q6058785"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"353338541ab10029c3a9c6d114054fac",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":101912681,
-    "wof:lastmodified":1566588222,
+    "wof:lastmodified":1582343862,
     "wof:name":"Caddebostan",
     "wof:parent_id":890462627,
     "wof:placetype":"locality",

--- a/data/859/041/07/85904107.geojson
+++ b/data/859/041/07/85904107.geojson
@@ -93,6 +93,9 @@
         "wd:id":"Q1592273"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"37893d2328566df2b908ce675fdf8a92",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588209,
+    "wof:lastmodified":1582343859,
     "wof:name":"Harbiye",
     "wof:parent_id":101912685,
     "wof:placetype":"neighbourhood",

--- a/data/859/041/15/85904115.geojson
+++ b/data/859/041/15/85904115.geojson
@@ -217,6 +217,9 @@
         "wd:id":"Q932886"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"71e21bfd2439cc81e9f4fbb0dd1d9d05",
     "wof:hierarchy":[
         {
@@ -232,7 +235,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588209,
+    "wof:lastmodified":1582343860,
     "wof:name":"Kadik\u00f6y",
     "wof:parent_id":101912677,
     "wof:placetype":"neighbourhood",

--- a/data/859/041/39/85904139.geojson
+++ b/data/859/041/39/85904139.geojson
@@ -144,6 +144,9 @@
         "wd:id":"Q6601541"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ec3624b7b7feb367e605713628fab57f",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588209,
+    "wof:lastmodified":1582343860,
     "wof:name":"Kurucesme",
     "wof:parent_id":101912663,
     "wof:placetype":"neighbourhood",

--- a/data/859/041/49/85904149.geojson
+++ b/data/859/041/49/85904149.geojson
@@ -137,6 +137,9 @@
         "wd:id":"Q2249546"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a93fcd981d20a7a9c9c4ed55de097c1b",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588209,
+    "wof:lastmodified":1582343860,
     "wof:name":"Ortakoy",
     "wof:parent_id":101912663,
     "wof:placetype":"neighbourhood",

--- a/data/859/041/59/85904159.geojson
+++ b/data/859/041/59/85904159.geojson
@@ -103,6 +103,9 @@
         "wk:page":"Tophane"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f9338cae9a128ef8430b05ea552dcde7",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588208,
+    "wof:lastmodified":1582343859,
     "wof:name":"Tophane",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/041/69/85904169.geojson
+++ b/data/859/041/69/85904169.geojson
@@ -98,6 +98,9 @@
         "wk:page":"Y\u0131ld\u0131z"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fd9d0ab41c84379f4a0c8df482c27df6",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588208,
+    "wof:lastmodified":1582343859,
     "wof:name":"Yildiz",
     "wof:parent_id":101912685,
     "wof:placetype":"neighbourhood",

--- a/data/859/041/73/85904173.geojson
+++ b/data/859/041/73/85904173.geojson
@@ -81,6 +81,9 @@
         "qs_pg:id":1310544
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d8953d13117297a59b06a581773db763",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588208,
+    "wof:lastmodified":1582343859,
     "wof:name":"Z\u00fcht\u00fcpa\u015fa",
     "wof:parent_id":101912677,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/31/85906531.geojson
+++ b/data/859/065/31/85906531.geojson
@@ -130,6 +130,9 @@
         "wd:id":"Q6069361"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9927ee44b85c8c54ee5c4fe5787ab297",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588210,
+    "wof:lastmodified":1582343860,
     "wof:name":"Piri Pasa",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/35/85906535.geojson
+++ b/data/859/065/35/85906535.geojson
@@ -76,6 +76,9 @@
         "qs_pg:id":909799
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d8a3784392a0b578ca1b8abaacda8c9b",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588209,
+    "wof:lastmodified":1582343860,
     "wof:name":"Kulaksiz",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/37/85906537.geojson
+++ b/data/859/065/37/85906537.geojson
@@ -124,6 +124,9 @@
         "wd:id":"Q6070576"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6b84e3fb830c6d094e0c31d32d17994a",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588211,
+    "wof:lastmodified":1582343860,
     "wof:name":"Yahya Kahya",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/41/85906541.geojson
+++ b/data/859/065/41/85906541.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":14471
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"170a82bd990cf20a37ef986a1afdabfd",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588212,
+    "wof:lastmodified":1582343860,
     "wof:name":"Catma Mescit",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/43/85906543.geojson
+++ b/data/859/065/43/85906543.geojson
@@ -103,6 +103,9 @@
         "qs_pg:id":237744
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"80bb1542f55b79ec65112be98ba8b9a8",
     "wof:hierarchy":[
         {
@@ -118,7 +121,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588210,
+    "wof:lastmodified":1582343860,
     "wof:name":"Evliya Celebi",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/45/85906545.geojson
+++ b/data/859/065/45/85906545.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":237745
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e51a6bbea3ffffb4be4be83941f1b907",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588210,
+    "wof:lastmodified":1582343860,
     "wof:name":"Asmali Mescit",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/47/85906547.geojson
+++ b/data/859/065/47/85906547.geojson
@@ -124,6 +124,9 @@
         "wd:id":"Q6073635"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7f462ab8dae95a54ae6d681834eb01eb",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588212,
+    "wof:lastmodified":1582343860,
     "wof:name":"Kamer Hatun",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/49/85906549.geojson
+++ b/data/859/065/49/85906549.geojson
@@ -279,6 +279,9 @@
         "wd:id":"Q43134"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"39ed359a265e3ca4b9885a1dec23b846",
     "wof:hierarchy":[
         {
@@ -294,7 +297,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588212,
+    "wof:lastmodified":1582343860,
     "wof:name":"Galatasaray",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/51/85906551.geojson
+++ b/data/859/065/51/85906551.geojson
@@ -73,6 +73,9 @@
         "qs_pg:id":237748
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3645b9cf0436b52103499688a75bfc0f",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588210,
+    "wof:lastmodified":1582343860,
     "wof:name":"Huseyinaga",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/53/85906553.geojson
+++ b/data/859/065/53/85906553.geojson
@@ -130,6 +130,9 @@
         "wd:id":"Q6071935"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"85c7c6ca17244993dc65d8c2a1f16340",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588211,
+    "wof:lastmodified":1582343860,
     "wof:name":"Sehit Muhtar",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/55/85906555.geojson
+++ b/data/859/065/55/85906555.geojson
@@ -267,6 +267,9 @@
         "wd:id":"Q1547370"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e4cdff1dfa7980ffd9a49720d093d1a5",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588211,
+    "wof:lastmodified":1582343860,
     "wof:name":"Kocatepe",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/59/85906559.geojson
+++ b/data/859/065/59/85906559.geojson
@@ -100,6 +100,9 @@
         "qs_pg:id":896995
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"59766b261a2703eb8cb4576531b66370",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588209,
+    "wof:lastmodified":1582343860,
     "wof:name":"In\u00f6n\u00fc",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/61/85906561.geojson
+++ b/data/859/065/61/85906561.geojson
@@ -111,6 +111,9 @@
         "wd:id":"Q419132"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7345295bb37bf88768b37f6087e04f43",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588209,
+    "wof:lastmodified":1582343860,
     "wof:name":"Yeni\u015fehir",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/63/85906563.geojson
+++ b/data/859/065/63/85906563.geojson
@@ -106,6 +106,9 @@
         "qs_pg:id":1118661
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"21358c01bd290c67904ba92dea6c2310",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588211,
+    "wof:lastmodified":1582343860,
     "wof:name":"Gumussuyu",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/65/85906565.geojson
+++ b/data/859/065/65/85906565.geojson
@@ -73,6 +73,9 @@
         "qs_pg:id":1087535
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"adb445256b0c31f2367151d0b276dee3",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588211,
+    "wof:lastmodified":1582343860,
     "wof:name":"Visnezade",
     "wof:parent_id":101912685,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/69/85906569.geojson
+++ b/data/859/065/69/85906569.geojson
@@ -76,6 +76,9 @@
         "qs_pg:id":484992
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"096b9a0c385a26fe86802614764b0cd8",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588209,
+    "wof:lastmodified":1582343860,
     "wof:name":"Cihannuma",
     "wof:parent_id":101912685,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/71/85906571.geojson
+++ b/data/859/065/71/85906571.geojson
@@ -99,6 +99,9 @@
         "wd:id":"Q3300867"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8b299b14ea6f1a2187588291dfb6524b",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588212,
+    "wof:lastmodified":1582343860,
     "wof:name":"Cihangir",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/73/85906573.geojson
+++ b/data/859/065/73/85906573.geojson
@@ -124,6 +124,9 @@
         "wd:id":"Q6069640"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f8c1160c27ffddf19cc574141413c360",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588210,
+    "wof:lastmodified":1582343860,
     "wof:name":"Katip Mustafa \u00c7elebi",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/77/85906577.geojson
+++ b/data/859/065/77/85906577.geojson
@@ -136,6 +136,9 @@
         "wd:id":"Q2706262"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c19e4bd703b5fb9966f3d149a6a7641d",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588212,
+    "wof:lastmodified":1582343860,
     "wof:name":"Karakoy",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/79/85906579.geojson
+++ b/data/859/065/79/85906579.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":899059
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"467b29aefb6be97dc90299b96b37879c",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588211,
+    "wof:lastmodified":1582343860,
     "wof:name":"Arap Cami",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/81/85906581.geojson
+++ b/data/859/065/81/85906581.geojson
@@ -76,6 +76,9 @@
         "qs_pg:id":899060
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c9132b3ab4a6cd70b09169cd7d5fe4f6",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588210,
+    "wof:lastmodified":1582343860,
     "wof:name":"Mueyyedzade",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/83/85906583.geojson
+++ b/data/859/065/83/85906583.geojson
@@ -76,6 +76,9 @@
         "qs_pg:id":237751
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e6e224952d4cfa944ed2720f4c06e65d",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588212,
+    "wof:lastmodified":1582343860,
     "wof:name":"Hacimimi",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/85/85906585.geojson
+++ b/data/859/065/85/85906585.geojson
@@ -134,6 +134,9 @@
         "wd:id":"Q6073023"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"57779c31c459b4484be63953bc0ae4eb",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588212,
+    "wof:lastmodified":1582343860,
     "wof:name":"Sahkulu",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/87/85906587.geojson
+++ b/data/859/065/87/85906587.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":366704
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fef3dbef0f0356348be65b2aca99c694",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588210,
+    "wof:lastmodified":1582343860,
     "wof:name":"Bereketzade",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/91/85906591.geojson
+++ b/data/859/065/91/85906591.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":1262742
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1fc98ed2ec6f88a471e24dfe13f5a119",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588211,
+    "wof:lastmodified":1582343860,
     "wof:name":"Selman A\u011fa",
     "wof:parent_id":101912675,
     "wof:placetype":"neighbourhood",

--- a/data/859/065/99/85906599.geojson
+++ b/data/859/065/99/85906599.geojson
@@ -160,6 +160,9 @@
         "wd:id":"Q3180968"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9d381e85d77db94b48e376018b0b9297",
     "wof:hierarchy":[
         {
@@ -175,7 +178,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588211,
+    "wof:lastmodified":1582343860,
     "wof:name":"G\u00fclfem Hatun",
     "wof:parent_id":101912675,
     "wof:placetype":"neighbourhood",

--- a/data/859/066/07/85906607.geojson
+++ b/data/859/066/07/85906607.geojson
@@ -128,6 +128,9 @@
         "wd:id":"Q6072958"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7fe2d82f3d1fb54bec035e3cc497d291",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588219,
+    "wof:lastmodified":1582343861,
     "wof:name":"Kilicali Pasa",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/066/13/85906613.geojson
+++ b/data/859/066/13/85906613.geojson
@@ -155,6 +155,9 @@
         "wd:id":"Q6101487"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"20047b60fca9eabbe6b2efeb4880126e",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588219,
+    "wof:lastmodified":1582343862,
     "wof:name":"Altunizade",
     "wof:parent_id":101912675,
     "wof:placetype":"neighbourhood",

--- a/data/859/293/53/85929353.geojson
+++ b/data/859/293/53/85929353.geojson
@@ -127,6 +127,9 @@
         "wd:id":"Q6059322"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"67f4e399741364cb7f7da3c97c128985",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588216,
+    "wof:lastmodified":1582343861,
     "wof:name":"Ko\u015fuyolu",
     "wof:parent_id":101912675,
     "wof:placetype":"neighbourhood",

--- a/data/859/293/59/85929359.geojson
+++ b/data/859/293/59/85929359.geojson
@@ -73,6 +73,9 @@
         "qs_pg:id":986664
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d890ce2ea8a54d216414333b1f066e3d",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588215,
+    "wof:lastmodified":1582343861,
     "wof:name":"Kultur",
     "wof:parent_id":101912663,
     "wof:placetype":"neighbourhood",

--- a/data/859/293/65/85929365.geojson
+++ b/data/859/293/65/85929365.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":1291066
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"098cdb1993f21f676e454387b2736cf3",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588216,
+    "wof:lastmodified":1582343861,
     "wof:name":"Fulya",
     "wof:parent_id":101912685,
     "wof:placetype":"neighbourhood",

--- a/data/859/293/77/85929377.geojson
+++ b/data/859/293/77/85929377.geojson
@@ -83,6 +83,9 @@
         "qs_pg:id":1090111
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5a85339caaaa3898e59def70a4602f13",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588216,
+    "wof:lastmodified":1582343861,
     "wof:name":"Murat Reis",
     "wof:parent_id":101912675,
     "wof:placetype":"neighbourhood",

--- a/data/859/293/83/85929383.geojson
+++ b/data/859/293/83/85929383.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q8080040"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fccf004d5ffc9fb8eaedaa76607110a7",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588216,
+    "wof:lastmodified":1582343861,
     "wof:name":"\u0130cadiye",
     "wof:parent_id":101912675,
     "wof:placetype":"neighbourhood",

--- a/data/859/293/93/85929393.geojson
+++ b/data/859/293/93/85929393.geojson
@@ -127,6 +127,9 @@
         "wd:id":"Q6093871"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d6ee8eeb2b4ba849f4ab4726e0e56093",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588215,
+    "wof:lastmodified":1582343861,
     "wof:name":"Balmumcu",
     "wof:parent_id":101912663,
     "wof:placetype":"neighbourhood",

--- a/data/859/294/03/85929403.geojson
+++ b/data/859/294/03/85929403.geojson
@@ -76,6 +76,9 @@
         "qs_pg:id":473098
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c1edca509c21956343e596c85a484786",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588213,
+    "wof:lastmodified":1582343860,
     "wof:name":"19 Mayis",
     "wof:parent_id":101912685,
     "wof:placetype":"neighbourhood",

--- a/data/859/294/07/85929407.geojson
+++ b/data/859/294/07/85929407.geojson
@@ -124,6 +124,9 @@
         "wd:id":"Q6078425"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"88edb5c3729f3170832d5d49094f91d8",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588214,
+    "wof:lastmodified":1582343861,
     "wof:name":"Gayrettepe",
     "wof:parent_id":101912685,
     "wof:placetype":"neighbourhood",

--- a/data/859/294/11/85929411.geojson
+++ b/data/859/294/11/85929411.geojson
@@ -76,6 +76,9 @@
         "qs_pg:id":473092
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9e2a157186f0c141a577178e4a7fe81a",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588213,
+    "wof:lastmodified":1582343860,
     "wof:name":"Istiklal",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/294/23/85929423.geojson
+++ b/data/859/294/23/85929423.geojson
@@ -127,6 +127,9 @@
         "qs_pg:id":425854
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"790a6b51abcb20efd055e04cad513c81",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588215,
+    "wof:lastmodified":1582343861,
     "wof:name":"Cumhuriyet",
     "wof:parent_id":101912685,
     "wof:placetype":"neighbourhood",

--- a/data/859/294/27/85929427.geojson
+++ b/data/859/294/27/85929427.geojson
@@ -89,6 +89,9 @@
         "qs_pg:id":204699
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d68f84b094127f2b988cba60b62b5994",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588213,
+    "wof:lastmodified":1582343860,
     "wof:name":"Hasanpa\u015fa",
     "wof:parent_id":101912677,
     "wof:placetype":"neighbourhood",

--- a/data/859/294/31/85929431.geojson
+++ b/data/859/294/31/85929431.geojson
@@ -127,6 +127,9 @@
         "wd:id":"Q6071040"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a3d04b00f6010098ebeba7f76e038bd5",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588214,
+    "wof:lastmodified":1582343861,
     "wof:name":"Ortabay\u0131r",
     "wof:parent_id":101912685,
     "wof:placetype":"neighbourhood",

--- a/data/859/294/37/85929437.geojson
+++ b/data/859/294/37/85929437.geojson
@@ -124,6 +124,9 @@
         "wd:id":"Q6075419"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5236c397a6ac1800902101b8c5fdd8e0",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588214,
+    "wof:lastmodified":1582343861,
     "wof:name":"Feneryolu",
     "wof:parent_id":101912677,
     "wof:placetype":"neighbourhood",

--- a/data/859/294/41/85929441.geojson
+++ b/data/859/294/41/85929441.geojson
@@ -158,6 +158,9 @@
         "wd:id":"Q6079063"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ef4e6d6f7bd3c1c21f653f8c8cd6201d",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588215,
+    "wof:lastmodified":1582343861,
     "wof:name":"Ulus",
     "wof:parent_id":101912663,
     "wof:placetype":"neighbourhood",

--- a/data/859/294/55/85929455.geojson
+++ b/data/859/294/55/85929455.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Mecidiyek\u00f6y"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"32a26da6756bd155339417cab8d8b27b",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588215,
+    "wof:lastmodified":1582343861,
     "wof:name":"Mecidiyek\u00f6y",
     "wof:parent_id":101912685,
     "wof:placetype":"neighbourhood",

--- a/data/859/294/67/85929467.geojson
+++ b/data/859/294/67/85929467.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":230829
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0bc906f2eec8918094068c1ca87159a9",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588213,
+    "wof:lastmodified":1582343860,
     "wof:name":"Arakiyeci Hac\u0131 Mehmet",
     "wof:parent_id":101912675,
     "wof:placetype":"neighbourhood",

--- a/data/859/294/73/85929473.geojson
+++ b/data/859/294/73/85929473.geojson
@@ -80,6 +80,9 @@
         "qs_pg:id":1294314
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7c1d37ceafab3702eb5fd3e9a992ad14",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588214,
+    "wof:lastmodified":1582343861,
     "wof:name":"Dikilitas",
     "wof:parent_id":101912685,
     "wof:placetype":"neighbourhood",

--- a/data/859/294/81/85929481.geojson
+++ b/data/859/294/81/85929481.geojson
@@ -83,6 +83,9 @@
         "qs_pg:id":222163
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5404656d9c7576d72682221f6c136bc4",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588214,
+    "wof:lastmodified":1582343861,
     "wof:name":"Cafera\u011fa",
     "wof:parent_id":101912675,
     "wof:placetype":"neighbourhood",

--- a/data/859/294/91/85929491.geojson
+++ b/data/859/294/91/85929491.geojson
@@ -73,6 +73,9 @@
         "qs_pg:id":900283
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fab399745bdfcfe6e95980d14510ee3c",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588214,
+    "wof:lastmodified":1582343861,
     "wof:name":"Halaskargazi",
     "wof:parent_id":101912685,
     "wof:placetype":"neighbourhood",

--- a/data/859/294/99/85929499.geojson
+++ b/data/859/294/99/85929499.geojson
@@ -78,6 +78,9 @@
         "wd:id":"Q2690028"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2fa9d6abb3b7fd26d79e088637a10768",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588214,
+    "wof:lastmodified":1582343861,
     "wof:name":"Ferikoy",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/295/01/85929501.geojson
+++ b/data/859/295/01/85929501.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":1136140
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3e4ecf2d245e9ff2db4ba067d6f6f13b",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588213,
+    "wof:lastmodified":1582343860,
     "wof:name":"Havuzba\u015f\u0131",
     "wof:parent_id":101912541,
     "wof:placetype":"neighbourhood",

--- a/data/859/295/65/85929565.geojson
+++ b/data/859/295/65/85929565.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":26657
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7de0c5ecb51b246ae98d4a00c651c9e2",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588213,
+    "wof:lastmodified":1582343860,
     "wof:name":"Kardelen",
     "wof:parent_id":101912785,
     "wof:placetype":"neighbourhood",

--- a/data/859/296/71/85929671.geojson
+++ b/data/859/296/71/85929671.geojson
@@ -69,6 +69,9 @@
         "qs_pg:id":508300
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a78fbf8b23a97056e6589b881b5daf66",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566588220,
+    "wof:lastmodified":1582343862,
     "wof:name":"Ortadogu",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/297/53/85929753.geojson
+++ b/data/859/297/53/85929753.geojson
@@ -88,6 +88,9 @@
         "qs_pg:id":473461
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"601e55381b4e5d68e51e3a19ddbc6a4a",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588220,
+    "wof:lastmodified":1582343862,
     "wof:name":"Ferah",
     "wof:parent_id":101912541,
     "wof:placetype":"neighbourhood",

--- a/data/859/297/85/85929785.geojson
+++ b/data/859/297/85/85929785.geojson
@@ -158,6 +158,9 @@
         "wd:id":"Q788634"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a21ae545bf65a22c93e0553c337a4185",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588220,
+    "wof:lastmodified":1582343862,
     "wof:name":"Bahcelievler",
     "wof:parent_id":101912673,
     "wof:placetype":"neighbourhood",

--- a/data/859/297/89/85929789.geojson
+++ b/data/859/297/89/85929789.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":473485
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"88e5cb29aa34fc247631f47595fb3d6e",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588220,
+    "wof:lastmodified":1582343862,
     "wof:name":"Tahilpazari",
     "wof:parent_id":101912923,
     "wof:placetype":"neighbourhood",

--- a/data/859/297/97/85929797.geojson
+++ b/data/859/297/97/85929797.geojson
@@ -130,6 +130,9 @@
         "wk:page":"Rumelihisar\u0131"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5881785ebc83dd634b308b65bb7a1629",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588220,
+    "wof:lastmodified":1582343862,
     "wof:name":"Rumeli Hisari",
     "wof:parent_id":101912659,
     "wof:placetype":"neighbourhood",

--- a/data/859/298/05/85929805.geojson
+++ b/data/859/298/05/85929805.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":1337646
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b401c4e3d7047aa54151dd0b3cb35fb3",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588218,
+    "wof:lastmodified":1582343861,
     "wof:name":"Kirazlitepe",
     "wof:parent_id":101912541,
     "wof:placetype":"neighbourhood",

--- a/data/859/298/09/85929809.geojson
+++ b/data/859/298/09/85929809.geojson
@@ -86,6 +86,10 @@
         "wk:page":"Stigler Regional Airport"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dfacdb0d2df30d90ac911727097182d1",
     "wof:hierarchy":[
         {
@@ -101,7 +105,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588219,
+    "wof:lastmodified":1582343861,
     "wof:name":"Pinarbasi",
     "wof:parent_id":101912921,
     "wof:placetype":"neighbourhood",

--- a/data/859/298/23/85929823.geojson
+++ b/data/859/298/23/85929823.geojson
@@ -81,6 +81,9 @@
         "qs_pg:id":1185486
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7120c840358278a7b504cb70078793b9",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588219,
+    "wof:lastmodified":1582343861,
     "wof:name":"Kepez",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/298/47/85929847.geojson
+++ b/data/859/298/47/85929847.geojson
@@ -82,6 +82,10 @@
         "qs_pg:id":204716
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"62ebdc52e3d9f78124ca0c5f6801fca8",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588219,
+    "wof:lastmodified":1582343861,
     "wof:name":"Kizilsaray",
     "wof:parent_id":101912923,
     "wof:placetype":"neighbourhood",

--- a/data/859/298/79/85929879.geojson
+++ b/data/859/298/79/85929879.geojson
@@ -76,6 +76,9 @@
         "qs_pg:id":1120065
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a3c42bb9f8842bfa9053181326725eb2",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588219,
+    "wof:lastmodified":1582343861,
     "wof:name":"\u00c7ubuklu",
     "wof:parent_id":101912645,
     "wof:placetype":"neighbourhood",

--- a/data/859/298/99/85929899.geojson
+++ b/data/859/298/99/85929899.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":1337676
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"27da6db3e1c2ef61303a9a8e7cc2c4d3",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588219,
+    "wof:lastmodified":1582343861,
     "wof:name":"Zuhuratbaba",
     "wof:parent_id":101912673,
     "wof:placetype":"neighbourhood",

--- a/data/859/299/09/85929909.geojson
+++ b/data/859/299/09/85929909.geojson
@@ -105,6 +105,10 @@
         "wk:page":"Asangaon"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"74dd0ecc3d08039a77b690487eee0091",
     "wof:hierarchy":[
         {
@@ -120,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588221,
+    "wof:lastmodified":1582343862,
     "wof:name":"G\u00fcrsu",
     "wof:parent_id":101912921,
     "wof:placetype":"neighbourhood",

--- a/data/859/299/13/85929913.geojson
+++ b/data/859/299/13/85929913.geojson
@@ -92,6 +92,10 @@
         "wk:page":"Esfezar"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a3aedd75141d8cca69f02df42f80ee45",
     "wof:hierarchy":[
         {
@@ -107,7 +111,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588222,
+    "wof:lastmodified":1582343862,
     "wof:name":"K\u00fclt\u00fcr",
     "wof:parent_id":101912921,
     "wof:placetype":"neighbourhood",

--- a/data/859/299/45/85929945.geojson
+++ b/data/859/299/45/85929945.geojson
@@ -83,6 +83,9 @@
         "qs_pg:id":1119944
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"466db2ebbbcacce1701c09e9f27ecb93",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588220,
+    "wof:lastmodified":1582343862,
     "wof:name":"Pinar",
     "wof:parent_id":101912651,
     "wof:placetype":"neighbourhood",

--- a/data/859/299/65/85929965.geojson
+++ b/data/859/299/65/85929965.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":1150938
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"69d5ac63e3c9bd13b2e22fe8903deedf",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588221,
+    "wof:lastmodified":1582343862,
     "wof:name":"Barbaros",
     "wof:parent_id":101912923,
     "wof:placetype":"neighbourhood",

--- a/data/859/299/73/85929973.geojson
+++ b/data/859/299/73/85929973.geojson
@@ -127,6 +127,9 @@
         "wd:id":"Q6074272"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8f01724bedea25003d58e6d4b695a432",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588221,
+    "wof:lastmodified":1582343862,
     "wof:name":"Sahrayicedid",
     "wof:parent_id":101912637,
     "wof:placetype":"neighbourhood",

--- a/data/859/299/87/85929987.geojson
+++ b/data/859/299/87/85929987.geojson
@@ -80,6 +80,9 @@
         "qs_pg:id":473495
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"67efdca35536cdd84c3cd5b6bd23638b",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588221,
+    "wof:lastmodified":1582343862,
     "wof:name":"Atakoy 9-10.",
     "wof:parent_id":101912671,
     "wof:placetype":"neighbourhood",

--- a/data/859/299/97/85929997.geojson
+++ b/data/859/299/97/85929997.geojson
@@ -140,6 +140,9 @@
         "wd:id":"Q6068876"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"60283f612cc0089249d4763e909b4742",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588222,
+    "wof:lastmodified":1582343862,
     "wof:name":"\u00c7inar",
     "wof:parent_id":101912637,
     "wof:placetype":"neighbourhood",

--- a/data/859/300/05/85930005.geojson
+++ b/data/859/300/05/85930005.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q6059115"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0d6a2c7db0e124d603ee34c8c7ce390a",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588206,
+    "wof:lastmodified":1582343859,
     "wof:name":"Kozyatagi",
     "wof:parent_id":101912637,
     "wof:placetype":"neighbourhood",

--- a/data/859/300/23/85930023.geojson
+++ b/data/859/300/23/85930023.geojson
@@ -121,6 +121,9 @@
         "wd:id":"Q6072587"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e2fb0e7dcac6b4fb168be1287b254fd2",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588206,
+    "wof:lastmodified":1582343859,
     "wof:name":"Barbaros",
     "wof:parent_id":101912637,
     "wof:placetype":"neighbourhood",

--- a/data/859/300/33/85930033.geojson
+++ b/data/859/300/33/85930033.geojson
@@ -73,6 +73,9 @@
         "gp:id":55871087
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"85ec42be486ff6ccfeb4744eb65d863a",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588206,
+    "wof:lastmodified":1582343859,
     "wof:name":"Tuzcular",
     "wof:parent_id":101912923,
     "wof:placetype":"neighbourhood",

--- a/data/859/300/37/85930037.geojson
+++ b/data/859/300/37/85930037.geojson
@@ -131,6 +131,9 @@
         "wd:id":"Q6069665"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4fe507fa4630f7343e6de905ba28438d",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588206,
+    "wof:lastmodified":1582343859,
     "wof:name":"\u00c7igdem",
     "wof:parent_id":101912645,
     "wof:placetype":"neighbourhood",

--- a/data/859/300/41/85930041.geojson
+++ b/data/859/300/41/85930041.geojson
@@ -156,6 +156,9 @@
         "wd:id":"Q327147"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4f7d457f9c79ef867b9c2e7c77267155",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588206,
+    "wof:lastmodified":1582343859,
     "wof:name":"H\u00fcrriyet",
     "wof:parent_id":101912685,
     "wof:placetype":"neighbourhood",

--- a/data/859/300/51/85930051.geojson
+++ b/data/859/300/51/85930051.geojson
@@ -90,6 +90,10 @@
         "wk:page":"Karatoya River"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c619bc9523652de1a038bab8946d4184",
     "wof:hierarchy":[
         {
@@ -105,7 +109,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588205,
+    "wof:lastmodified":1582343859,
     "wof:name":"Meltem",
     "wof:parent_id":101912921,
     "wof:placetype":"neighbourhood",

--- a/data/859/300/71/85930071.geojson
+++ b/data/859/300/71/85930071.geojson
@@ -81,6 +81,10 @@
         "wd:id":"Q7915987"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"4288ab51f735b9ed0b82dbd555e8b589",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588207,
+    "wof:lastmodified":1582343859,
     "wof:name":"Varlik",
     "wof:parent_id":101912921,
     "wof:placetype":"neighbourhood",

--- a/data/859/300/85/85930085.geojson
+++ b/data/859/300/85/85930085.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":1115476
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ed6cf9ded4409b482944b6dfc36094c0",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588207,
+    "wof:lastmodified":1582343859,
     "wof:name":"Hasim Sican",
     "wof:parent_id":101912923,
     "wof:placetype":"neighbourhood",

--- a/data/859/300/93/85930093.geojson
+++ b/data/859/300/93/85930093.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":1337729
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"674ecd6ec98860f56f154ebf4e2ee9cf",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588206,
+    "wof:lastmodified":1582343859,
     "wof:name":"Bulgurlu",
     "wof:parent_id":101912677,
     "wof:placetype":"neighbourhood",

--- a/data/859/301/03/85930103.geojson
+++ b/data/859/301/03/85930103.geojson
@@ -121,6 +121,9 @@
         "wd:id":"Q6071751"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c7801a8c775b9953d1e899961f484b20",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588207,
+    "wof:lastmodified":1582343859,
     "wof:name":"Emniyettepe",
     "wof:parent_id":101913185,
     "wof:placetype":"neighbourhood",

--- a/data/859/301/07/85930107.geojson
+++ b/data/859/301/07/85930107.geojson
@@ -78,6 +78,10 @@
         "wk:page":"Kleine Sinn"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"5f11c18772970dac34c863dbaf228ee3",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588207,
+    "wof:lastmodified":1582343859,
     "wof:name":"G\u00fcvenlik",
     "wof:parent_id":101912921,
     "wof:placetype":"neighbourhood",

--- a/data/859/301/11/85930111.geojson
+++ b/data/859/301/11/85930111.geojson
@@ -120,6 +120,10 @@
         "wk:page":"Balka"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c10b31e66468ca847522f810682fb36e",
     "wof:hierarchy":[
         {
@@ -135,7 +139,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588207,
+    "wof:lastmodified":1582343859,
     "wof:name":"Bah\u00e7elievler",
     "wof:parent_id":101912923,
     "wof:placetype":"neighbourhood",

--- a/data/859/301/13/85930113.geojson
+++ b/data/859/301/13/85930113.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":893170
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c49a5b12291bd02b7d6bac43ff0f9fcd",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588208,
+    "wof:lastmodified":1582343859,
     "wof:name":"Sirinyali",
     "wof:parent_id":101912923,
     "wof:placetype":"neighbourhood",

--- a/data/859/301/25/85930125.geojson
+++ b/data/859/301/25/85930125.geojson
@@ -86,6 +86,9 @@
         "wd:id":"Q12813027"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"be835b6816b71ee965656465c3477037",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588208,
+    "wof:lastmodified":1582343859,
     "wof:name":"I\u00e7erenk\u00f6y",
     "wof:parent_id":101912637,
     "wof:placetype":"neighbourhood",

--- a/data/859/301/29/85930129.geojson
+++ b/data/859/301/29/85930129.geojson
@@ -171,6 +171,9 @@
         "wd:id":"Q328331"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d83f70f71d6675e892cdf1d6f6f13857",
     "wof:hierarchy":[
         {
@@ -186,7 +189,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588207,
+    "wof:lastmodified":1582343859,
     "wof:name":"Fevzi Cakmak",
     "wof:parent_id":101912671,
     "wof:placetype":"neighbourhood",

--- a/data/859/301/33/85930133.geojson
+++ b/data/859/301/33/85930133.geojson
@@ -106,6 +106,9 @@
         "qs_pg:id":1337746
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"10e550f0b177ffe743e14cb4fcd7dec7",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588207,
+    "wof:lastmodified":1582343859,
     "wof:name":"Atat\u00fcrk",
     "wof:parent_id":101912541,
     "wof:placetype":"neighbourhood",

--- a/data/859/301/41/85930141.geojson
+++ b/data/859/301/41/85930141.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1337772
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bd69d22543195e07fbb4372110791dc7",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588208,
+    "wof:lastmodified":1582343859,
     "wof:name":"\u00c7ay Yolu",
     "wof:parent_id":101912785,
     "wof:placetype":"neighbourhood",

--- a/data/859/301/51/85930151.geojson
+++ b/data/859/301/51/85930151.geojson
@@ -94,6 +94,9 @@
         "wk:page":"Etiler"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c4774108c6cb4ab543ee3a5e1f5b71a3",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588207,
+    "wof:lastmodified":1582343859,
     "wof:name":"Etiler",
     "wof:parent_id":101912663,
     "wof:placetype":"neighbourhood",

--- a/data/859/301/75/85930175.geojson
+++ b/data/859/301/75/85930175.geojson
@@ -136,6 +136,10 @@
         "qs_pg:id":277031
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f5b8772e588a093ac6537a3d14b726ae",
     "wof:hierarchy":[
         {
@@ -151,7 +155,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588207,
+    "wof:lastmodified":1582343859,
     "wof:name":"Fener",
     "wof:parent_id":101912923,
     "wof:placetype":"neighbourhood",

--- a/data/859/302/11/85930211.geojson
+++ b/data/859/302/11/85930211.geojson
@@ -130,6 +130,9 @@
         "wd:id":"Q6078350"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"46a269f8ba90e6d95e174c93eebeda7d",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588218,
+    "wof:lastmodified":1582343861,
     "wof:name":"Kavacik",
     "wof:parent_id":101912645,
     "wof:placetype":"neighbourhood",

--- a/data/859/302/19/85930219.geojson
+++ b/data/859/302/19/85930219.geojson
@@ -83,6 +83,9 @@
         "wd:id":"Q4852587"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"be31a44ab41b3538c1f9d9f6bd641e2c",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588218,
+    "wof:lastmodified":1582343861,
     "wof:name":"Baltalimani",
     "wof:parent_id":101912659,
     "wof:placetype":"neighbourhood",

--- a/data/859/302/43/85930243.geojson
+++ b/data/859/302/43/85930243.geojson
@@ -86,6 +86,10 @@
         "wk:page":"Mandyani River"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5d398ab21e5ebca1dc672c66a2115954",
     "wof:hierarchy":[
         {
@@ -101,7 +105,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588218,
+    "wof:lastmodified":1582343861,
     "wof:name":"Zerdalilik",
     "wof:parent_id":101912923,
     "wof:placetype":"neighbourhood",

--- a/data/859/302/67/85930267.geojson
+++ b/data/859/302/67/85930267.geojson
@@ -148,6 +148,10 @@
         "qs_pg:id":268958
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dfee95384edfa14791781ea130ada6ed",
     "wof:hierarchy":[
         {
@@ -163,7 +167,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588218,
+    "wof:lastmodified":1582343861,
     "wof:name":"Kanal",
     "wof:parent_id":101912921,
     "wof:placetype":"neighbourhood",

--- a/data/859/346/41/85934641.geojson
+++ b/data/859/346/41/85934641.geojson
@@ -704,6 +704,9 @@
         "wd:id":"Q1769191"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f1a95e1ba8abf7b7621f61f3d2d1a34",
     "wof:hierarchy":[
         {
@@ -719,7 +722,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588216,
+    "wof:lastmodified":1582343861,
     "wof:name":"Turgut",
     "wof:parent_id":101910981,
     "wof:placetype":"neighbourhood",

--- a/data/859/347/21/85934721.geojson
+++ b/data/859/347/21/85934721.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":791850
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"5b99c40723f48af55e0776d4a66a31dd",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588217,
+    "wof:lastmodified":1582343861,
     "wof:name":"Karabas",
     "wof:parent_id":101912635,
     "wof:placetype":"neighbourhood",

--- a/data/859/347/35/85934735.geojson
+++ b/data/859/347/35/85934735.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":884336
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"823b98c1035d1088e07633917d6927b6",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588217,
+    "wof:lastmodified":1582343861,
     "wof:name":"Hizirbey",
     "wof:parent_id":101912783,
     "wof:placetype":"neighbourhood",

--- a/data/859/347/51/85934751.geojson
+++ b/data/859/347/51/85934751.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1091860
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"4567949a96ba17ec3576128b58bd7a50",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588217,
+    "wof:lastmodified":1582343861,
     "wof:name":"Yenibaglar",
     "wof:parent_id":101912873,
     "wof:placetype":"neighbourhood",

--- a/data/859/347/59/85934759.geojson
+++ b/data/859/347/59/85934759.geojson
@@ -93,6 +93,9 @@
         "wd:id":"Q16281782"
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1b262a93413526a943ab8efbb3c6e155",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588217,
+    "wof:lastmodified":1582343861,
     "wof:name":"S\u00fcmer",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/347/61/85934761.geojson
+++ b/data/859/347/61/85934761.geojson
@@ -99,6 +99,10 @@
         "qs_pg:id":8994
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"45e83bb4f103031309f0ccbd50b16623",
     "wof:hierarchy":[
         {
@@ -114,7 +118,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588216,
+    "wof:lastmodified":1582343861,
     "wof:name":"Istiklal",
     "wof:parent_id":101912871,
     "wof:placetype":"neighbourhood",

--- a/data/859/347/67/85934767.geojson
+++ b/data/859/347/67/85934767.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":483010
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c0bbd9f1109c2ab317c20d21e948cc29",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588217,
+    "wof:lastmodified":1582343861,
     "wof:name":"Kirmizitoprak",
     "wof:parent_id":101912871,
     "wof:placetype":"neighbourhood",

--- a/data/859/347/71/85934771.geojson
+++ b/data/859/347/71/85934771.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":483012
     },
     "wof:country":"TU",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7af3e1bb6262fbce0f989d55ed1e25d9",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566588218,
+    "wof:lastmodified":1582343861,
     "wof:name":"Hosnudiye",
     "wof:parent_id":101912871,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.